### PR TITLE
Changed docker network to host

### DIFF
--- a/docker-shogigui
+++ b/docker-shogigui
@@ -92,7 +92,7 @@ function build_docker_image() {
     info "Building docker image with tag : shogigui${SHOGIGUI_VERSION}:yaneuraou${YANEURAOU_VERSION}-${YANEURAOU_TARGET_CPU,,}"
     echo
 
-    docker build --build-arg NPROC=$(nproc) \
+    docker build --network=host --build-arg NPROC=$(nproc) \
                  --build-arg SHOGIGUI_VERSION=$SHOGIGUI_VERSION \
                  --build-arg YANEURAOU_VERSION=$YANEURAOU_VERSION \
                  --build-arg YANEURAOU_TARGET_CPU=$YANEURAOU_TARGET_CPU \


### PR DESCRIPTION
# Problem

The problem occurs when ubuntu docker container tries to `apt get install`, or pip3 tries to get `gdown` package.
Since the network has not exposed to the Internet, it is not possible to get packages. 


# Solution 

Adding `--network=host` to the docker command will fix this problem.

--- 
BTW, thanks for the dockerization of ShogiGUI in Linux!  I've been waiting for this for a long time! 